### PR TITLE
Adding option for custom theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 Command-line interface for [mermaid](https://mermaidjs.github.io/).
 
-This CLI tool takes a mermaid definition file as input and generates svg/png file as output.
+This CLI tool takes a mermaid definition file as input and generates svg/png/pdf file as output.
 
 
 ## Installation
 
-```
+```sh
 yarn global add mermaid.cli
 ```
 
  Or
 
-```
+```sh
 npm install -g mermaid.cli
 ```
 
@@ -22,31 +22,31 @@ Please install via `npm` instead of `yarn` if you encounter [this issue](https:/
 
 ## Examples
 
-```
+```sh
 mmdc -i input.mmd -o output.svg
 ```
 
-```
+```sh
 mmdc -i input.mmd -o output.png
 ```
 
-```
+```sh
 mmdc -i input.mmd -o output.pdf
 ```
 
-```
+```sh
 mmdc -i input.mmd -o output.svg -w 1024 -H 768
 ```
 
-```
+```sh
 mmdc -i input.mmd -t forest
 ```
 
-```
+```sh
 mmdc -i input.mmd -o output.png -b '#FFF000'
 ```
 
-```
+```sh
 mmdc -i input.mmd -o output.png -b transparent
 ```
 
@@ -55,15 +55,14 @@ mmdc -i input.mmd -o output.png -b transparent
 
 Please run the following command to see the latest options:
 
-```
+```sh
 mmdc -h
 ```
 
 The following is for your quick reference (may not be the latest version):
 
-```
+```text
 Usage: mmdc [options]
-
 
   Options:
 
@@ -76,5 +75,6 @@ Usage: mmdc [options]
     -b, --backgroundColor [backgroundColor]  Background color. Example: transparent, red, '#F0F0F0'. Optional. Default: white
     -c, --configFile [config]                JSON configuration file for mermaid. Optional
     -C, --cssFile [cssFile]                  CSS alternate file for mermaid. Optional
+    -T, --customTheme <customThemeCssFile>   CSS file replacing CSS injected into SVG container. Optional
     -h, --help                               output usage information
 ```

--- a/index.js
+++ b/index.js
@@ -14,14 +14,14 @@ const error = (message) => {
 
 commander
   .version(pkg.version)
-  .option('-t, --theme [name]', 'Theme of the chart, could be default, forest, dark or neutral. Optional. Default: default', /^default|forest|dark|neutral$/, 'default')
-  .option('-w, --width [width]', 'Width of the page. Optional. Default: 800', /^\d+$/, '800')
-  .option('-H, --height [height]', 'Height of the page. Optional. Default: 600', /^\d+$/, '600')
+  .option('-t, --theme <name>', 'Theme of the chart, could be default, forest, dark or neutral. Optional. Default: default', /^default|forest|dark|neutral$/, 'default')
+  .option('-w, --width <width>', 'Width of the page. Optional. Default: 800', /^\d+$/, '800')
+  .option('-H, --height <height>', 'Height of the page. Optional. Default: 600', /^\d+$/, '600')
   .option('-i, --input <input>', 'Input mermaid file. Required.')
-  .option('-o, --output [output]', 'Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"')
-  .option('-b, --backgroundColor [backgroundColor]', 'Background color. Example: transparent, red, \'#F0F0F0\'. Optional. Default: white')
-  .option('-c, --configFile [config]', 'JSON configuration file for mermaid. Optional')
-  .option('-C, --cssFile [cssFile]', 'CSS alternate file for mermaid. Optional')
+  .option('-o, --output <output>', 'Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"')
+  .option('-b, --backgroundColor <backgroundColor>', 'Background color. Example: transparent, red, \'#F0F0F0\'. Optional. Default: white')
+  .option('-c, --configFile <config>', 'JSON configuration file for mermaid. Optional')
+  .option('-C, --cssFile <cssFile>', 'CSS alternate file for mermaid. Optional')
   .option('-T, --customTheme <customThemeCssFile>', 'CSS file replacing CSS injected into SVG container. Optional')
   .parse(process.argv)
 

--- a/test/custom-theme.css
+++ b/test/custom-theme.css
@@ -1,0 +1,351 @@
+/* Flowchart variables */
+/* Sequence Diagram variables */
+/* Gantt chart variables */
+.mermaid .label {
+  color: #333;
+}
+.node rect,
+.node circle,
+.node ellipse,
+.node polygon {
+  fill: #FFECEC;
+  stroke: #FFCCCC;
+  stroke-width: 1px;
+}
+.arrowheadPath {
+  fill: #111111;
+}
+.edgePath .path {
+  stroke: #111111;
+}
+.edgeLabel {
+  background-color: #e8e8e8;
+}
+.cluster rect {
+  fill: #ffffde !important;
+  rx: 4 !important;
+  stroke: #aaaa33 !important;
+  stroke-width: 1px !important;
+}
+.cluster text {
+  fill: #333;
+}
+.actor {
+  stroke: #FFCCCC;
+  fill: #FFECEC;
+}
+text.actor {
+  fill: black;
+  stroke: none;
+}
+.actor-line {
+  stroke: grey;
+}
+.messageLine0 {
+  stroke-width: 1.5;
+  stroke-dasharray: "2 2";
+  marker-end: "url(#arrowhead)";
+  stroke: #333;
+}
+.messageLine1 {
+  stroke-width: 1.5;
+  stroke-dasharray: "2 2";
+  stroke: #333;
+}
+#arrowhead {
+  fill: #333;
+}
+#crosshead path {
+  fill: #333 !important;
+  stroke: #333 !important;
+}
+.messageText {
+  fill: #333;
+  stroke: none;
+}
+.labelBox {
+  stroke: #FFCCCC;
+  fill: #FFECEC;
+}
+.labelText {
+  fill: black;
+  stroke: none;
+}
+.loopText {
+  fill: black;
+  stroke: none;
+}
+.loopLine {
+  stroke-width: 2;
+  stroke-dasharray: "2 2";
+  marker-end: "url(#arrowhead)";
+  stroke: #FFCCCC;
+}
+.note {
+  stroke: #aaaa33;
+  fill: #fff5ad;
+}
+.noteText {
+  fill: black;
+  stroke: none;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 14px;
+}
+/** Section styling */
+.section {
+  stroke: none;
+  opacity: 0.2;
+}
+.section0 {
+  fill: rgba(102, 102, 255, 0.49);
+}
+.section2 {
+  fill: #fff400;
+}
+.section1,
+.section3 {
+  fill: white;
+  opacity: 0.2;
+}
+.sectionTitle0 {
+  fill: #333;
+}
+.sectionTitle1 {
+  fill: #333;
+}
+.sectionTitle2 {
+  fill: #333;
+}
+.sectionTitle3 {
+  fill: #333;
+}
+.sectionTitle {
+  text-anchor: start;
+  font-size: 11px;
+  text-height: 14px;
+}
+/* Grid and axis */
+.grid .tick {
+  stroke: lightgrey;
+  opacity: 0.3;
+  shape-rendering: crispEdges;
+}
+.grid path {
+  stroke-width: 0;
+}
+/* Today line */
+.today {
+  fill: none;
+  stroke: red;
+  stroke-width: 2px;
+}
+/* Task styling */
+/* Default task */
+.task {
+  stroke-width: 2;
+}
+.taskText {
+  text-anchor: middle;
+  font-size: 11px;
+}
+.taskTextOutsideRight {
+  fill: black;
+  text-anchor: start;
+  font-size: 11px;
+}
+.taskTextOutsideLeft {
+  fill: black;
+  text-anchor: end;
+  font-size: 11px;
+}
+/* Specific task settings for the sections*/
+.taskText0,
+.taskText1,
+.taskText2,
+.taskText3 {
+  fill: white;
+}
+.task0,
+.task1,
+.task2,
+.task3 {
+  fill: #8a90dd;
+  stroke: #534fbc;
+}
+.taskTextOutside0,
+.taskTextOutside2 {
+  fill: black;
+}
+.taskTextOutside1,
+.taskTextOutside3 {
+  fill: black;
+}
+/* Active task */
+.active0,
+.active1,
+.active2,
+.active3 {
+  fill: #bfc7ff;
+  stroke: #534fbc;
+}
+.activeText0,
+.activeText1,
+.activeText2,
+.activeText3 {
+  fill: black !important;
+}
+/* Completed task */
+.done0,
+.done1,
+.done2,
+.done3 {
+  stroke: grey;
+  fill: lightgrey;
+  stroke-width: 2;
+}
+.doneText0,
+.doneText1,
+.doneText2,
+.doneText3 {
+  fill: black !important;
+}
+/* Tasks on the critical line */
+.crit0,
+.crit1,
+.crit2,
+.crit3 {
+  stroke: #ff8888;
+  fill: red;
+  stroke-width: 2;
+}
+.activeCrit0,
+.activeCrit1,
+.activeCrit2,
+.activeCrit3 {
+  stroke: #ff8888;
+  fill: #bfc7ff;
+  stroke-width: 2;
+}
+.doneCrit0,
+.doneCrit1,
+.doneCrit2,
+.doneCrit3 {
+  stroke: #ff8888;
+  fill: lightgrey;
+  stroke-width: 2;
+  cursor: pointer;
+  shape-rendering: crispEdges;
+}
+.doneCritText0,
+.doneCritText1,
+.doneCritText2,
+.doneCritText3 {
+  fill: black !important;
+}
+.activeCritText0,
+.activeCritText1,
+.activeCritText2,
+.activeCritText3 {
+  fill: black !important;
+}
+.titleText {
+  text-anchor: middle;
+  font-size: 18px;
+  fill: black;
+}
+g.classGroup text {
+  fill: #9370DB;
+  stroke: none;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 10px;
+}
+g.classGroup rect {
+  fill: #FFECEC;
+  stroke: #9370DB;
+}
+g.classGroup line {
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+svg .classLabel .box {
+  stroke: none;
+  stroke-width: 0;
+  fill: #FFECEC;
+  opacity: 0.5;
+}
+svg .classLabel .label {
+  fill: #9370DB;
+  font-size: 10px;
+}
+.relation {
+  stroke: #9370DB;
+  stroke-width: 1;
+  fill: none;
+}
+.composition {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#compositionStart {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#compositionEnd {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+.aggregation {
+  fill: #FFECEC;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#aggregationStart {
+  fill: #FFECEC;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#aggregationEnd {
+  fill: #FFECEC;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#dependencyStart {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#dependencyEnd {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#extensionStart {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+#extensionEnd {
+  fill: #9370DB;
+  stroke: #9370DB;
+  stroke-width: 1;
+}
+.node text {
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 14px;
+}
+div.mermaidTooltip {
+  position: absolute;
+  text-align: center;
+  max-width: 200px;
+  padding: 2px;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 12px;
+  background: #ffffde;
+  border: 1px solid #aaaa33;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 100;
+}


### PR DESCRIPTION
OK - per the discussion on issue #18 , here is the PR which adds a new -T / --customTheme option to the CLI which will fully replace the contents of the style element in the SVG tag.  I also added a slightly modified version of the base mermaid.css file so that the effect of new option can be seen.

Ideally, the base mermaid config would allow this, but I checked the code and it does not support using anything but the built-in themes via the JSON config file.