### PR TITLE
Swap chalk for turbocolor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const commander = require('commander')
-const chalk = require('chalk')
+const tc = require('turbocolor')
 const fs = require('fs')
 const path = require('path')
 const puppeteer = require('puppeteer')
@@ -8,7 +8,7 @@ const puppeteer = require('puppeteer')
 const pkg = require('./package.json')
 
 const error = message => {
-  console.log(chalk.red(`\n${message}\n`))
+  console.log(tc.red(`\n${message}\n`))
   process.exit(1)
 }
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "prepublishOnly": "babel ./index.js --out-file ./index.bundle.js"
   },
   "dependencies": {
-    "chalk": "^2.4.1",
     "commander": "^2.15.1",
-    "puppeteer": "^1.4.0"
+    "puppeteer": "^1.4.0",
+    "turbocolor": "2.3.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",


### PR DESCRIPTION
Hello @tylerlong! 👋 

This PR swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor). It loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API (see [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)).

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

Let me know if this is acceptable to you. Cheers!