### PR TITLE
Adjust PDF page size to fit chart size

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,17 @@ backgroundColor = backgroundColor || 'white';
     })
     await page.screenshot({ path: output, clip, omitBackground: backgroundColor === 'transparent' })
   } else { // pdf
-    await page.pdf({ path: output, printBackground: backgroundColor !== 'transparent' })
+    const clip = yield page.$eval('svg', function (svg) {
+      const react = svg.getBoundingClientRect()
+      return { x: react.left, y: react.top, width: react.width, height: react.height }
+    })
+    yield page.pdf({
+      path: output,
+      printBackground: backgroundColor !== 'transparent',
+      width: (Math.ceil(clip.width) + clip.x*2) + 'px',
+      height: (Math.ceil(clip.height) + clip.y*2) + 'px',
+      pageRanges: '1-1',
+    })
   }
 
   browser.close()


### PR DESCRIPTION
Currently PDFs produced by the tool have a fixed page size, independent from the chart size and dictated by the internal behavior of Puppeteer (the [documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions) says that in the absence of specific options the page size is always Letter).

This produces pages with excessive blank spaces (as mentioned in #48) and is also an anomaly with respect to results obtained with other output formats, since both SVGs and PNGs do fit perfectly the chart size.

This patch adjust the PDF page size in order to fit the chart dimension, also including the margins automatically added by Chromium, resulting in PDFs without blank spaces.

The patch has been tested with all the sample files.
