### PR TITLE
Support standard input for graph definition and optionally write to standard output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ Usage: mmdc [options]
     -t, --theme [theme]                             Theme of the chart, could be default, forest, dark or neutral. Optional. Default: default (default: default)
     -w, --width [width]                             Width of the page. Optional. Default: 800 (default: 800)
     -H, --height [height]                           Height of the page. Optional. Default: 600 (default: 600)
-    -i, --input <input>                             Input mermaid file. Required.
-    -o, --output [output]                           Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"
+    -f, --format [format]                           Output format. Optional. Default: inferred from the file extension or svg
+    -i, --input [input]                             Input mermaid file. Optional. Default: standard input
+    -o, --output [output]                           Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg" or standard output
     -b, --backgroundColor [backgroundColor]         Background color. Example: transparent, red, '#F0F0F0'. Optional. Default: white
     -c, --configFile [configFile]                   JSON configuration file for mermaid. Optional
     -C, --cssFile [cssFile]                         CSS file for the page. Optional

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ mmdc -i input.mmd -o output.png -b '#FFF000'
 mmdc -i input.mmd -o output.png -b transparent
 ```
 
+```
+mmdc -f png < input.mmd > output.png
+```
+
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ commander
   .option('-H, --height [height]', 'Height of the page. Optional. Default: 600', /^\d+$/, '600')
   .option('-f, --format [format]', 'Output format. Optional. Default: inferred from the file extension or svg')
   .option('-i, --input [input]', 'Input mermaid file. Optional. Default: standard input')
-  .option('-o, --output [output]', 'Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"')
+  .option('-o, --output [output]', 'Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg" or standard output')
   .option('-b, --backgroundColor [backgroundColor]', 'Background color. Example: transparent, red, \'#F0F0F0\'. Optional. Default: white')
   .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid. Optional')
   .option('-C, --cssFile [cssFile]', 'CSS file for the page. Optional')

--- a/index.js
+++ b/index.js
@@ -37,18 +37,15 @@ const createMemoryStream = input => {
   return stringStream
 }
 
-const writeStreamToStream = async (inputStream, outputStream, standardOutput) => {
+const writeStreamToStream = async (inputStream, outputStream) => {
+  const stdout = outputStream === process.stdout
   return new Promise((resolve, reject) => {
     outputStream
       .on('error', reject)
       .on('finish', () => outputStream.close(resolve))
     inputStream
       .on('error', reject)
-      .on('end', () => {
-        if (standardOutput) {
-          process.nextTick(resolve)
-        }
-      })
+      .on('end', () => stdout && process.nextTick(resolve))
       .pipe(outputStream)
       .on('error', reject)
   })
@@ -171,7 +168,7 @@ backgroundColor = backgroundColor || 'white';
   content = createMemoryStream(content)
 
   const target = output ? fs.createWriteStream(output) : process.stdout
-  await writeStreamToStream(content, target, !output)
+  await writeStreamToStream(content, target)
 
   browser.close()
 })()

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const readStreamToString = async (inputStream, encoding) => {
 }
 
 const createMemoryStream = input => {
-  var stringStream = new stream.Readable()
+  const stringStream = new stream.Readable()
   stringStream.push(input)
   stringStream.push(null)
   return stringStream

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ if (input) {
 // check format
 if (format) {
   if (!/^svg|png|pdf$/.test(format)) {
-    error('Output format must be ".svg", ".png" or ".pdf"')
+    error('Output format must be "svg", "png" or "pdf"')
   }
 }
 


### PR DESCRIPTION
Use standard input if no input file is provided and similarly for the output

If the output file is not provided, the output format cannot be inferred from the file extension. It can be specified by the new `format` parameter then.

It can be used on the command line or in a shell script to `echo` a string with the graph definition to the `mmdc` script. As asked by #57. The output SVG can be set to a shell variable too.