### PR TITLE
Wrap asynchronous statements in try & catch blocks to fail gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,25 @@ const puppeteer = require('puppeteer')
 
 const pkg = require('./package.json')
 
+const logMessage = (color, message, details) => {
+  console.log(chalk[color](`\n${message}\n`))
+  if (details) {
+    console.log(details)
+  }
+}
+
+const logError = (message, details) => logMessage('red', message, details)
+const logWarning = (message, details) => logMessage('yellow', message, details)
+
+const rethrowError = (message, error, exitCode) => {
+  const newError = new Error(message)
+  newError.details = error.message
+  newError.exitCode = exitCode
+  throw newError
+}
+
 const error = message => {
-  console.log(chalk.red(`\n${message}\n`))
+  logError(message)
   process.exit(1)
 }
 
@@ -79,45 +96,86 @@ width = parseInt(width)
 height = parseInt(height)
 backgroundColor = backgroundColor || 'white';
 
-(async () => {
-  const browser = await puppeteer.launch(puppeteerConfig)
-  const page = await browser.newPage()
-  page.setViewport({ width, height })
-  await page.goto(`file://${path.join(__dirname, 'index.html')}`)
-  await page.evaluate(`document.body.style.background = '${backgroundColor}'`)
-  const definition = fs.readFileSync(input, 'utf-8')
+let browser
 
-  await page.$eval('#container', (container, definition, mermaidConfig, myCSS) => {
-    container.innerHTML = definition
-    window.mermaid.initialize(mermaidConfig)
-
-    if (myCSS) {
-      const head = window.document.head || window.document.getElementsByTagName('head')[0]
-      const style = document.createElement('style')
-      style.type = 'text/css'
-      if (style.styleSheet) {
-        style.styleSheet.cssText = myCSS
-      } else {
-        style.appendChild(document.createTextNode(myCSS))
-      }
-      head.appendChild(style)
-    }
-
-    window.mermaid.init(undefined, container)
-  }, definition, mermaidConfig, myCSS)
-
-  if (output.endsWith('svg')) {
-    const svg = await page.$eval('#container', container => container.innerHTML)
-    fs.writeFileSync(output, svg)
-  } else if (output.endsWith('png')) {
-    const clip = await page.$eval('svg', svg => {
-      const react = svg.getBoundingClientRect()
-      return { x: react.left, y: react.top, width: react.width, height: react.height }
-    })
-    await page.screenshot({ path: output, clip, omitBackground: backgroundColor === 'transparent' })
-  } else { // pdf
-    await page.pdf({ path: output, printBackground: backgroundColor !== 'transparent' })
+const openBrowserPage = async () => {
+  try {
+    browser = await puppeteer.launch(puppeteerConfig)
+    const page = await browser.newPage()
+    page.setViewport({ width, height })
+    await page.goto(`file://${path.join(__dirname, 'index.html')}`)
+    await page.evaluate(`document.body.style.background = '${backgroundColor}'`)
+    return page
+  } catch (error) {
+    rethrowError('Launching Chrome in the headless mode failed.', error, 2)
   }
+}
 
-  browser.close()
+const loadGraphDefinition = async page => {
+  try {
+    const definition = fs.readFileSync(input, 'utf-8')
+
+    await page.$eval('#container', (container, definition, mermaidConfig, myCSS) => {
+      container.innerHTML = definition
+      window.mermaid.initialize(mermaidConfig)
+
+      if (myCSS) {
+        const head = window.document.head || window.document.getElementsByTagName('head')[0]
+        const style = document.createElement('style')
+        style.type = 'text/css'
+        if (style.styleSheet) {
+          style.styleSheet.cssText = myCSS
+        } else {
+          style.appendChild(document.createTextNode(myCSS))
+        }
+        head.appendChild(style)
+      }
+
+      window.mermaid.init(undefined, container)
+    }, definition, mermaidConfig, myCSS)
+  } catch (error) {
+    rethrowError('Processing the graph definition failed.', error, 3)
+  }
+}
+
+const saveGraphOutput = async page => {
+  try {
+    if (output.endsWith('svg')) {
+      const svg = await page.$eval('#container', container => container.innerHTML)
+      fs.writeFileSync(output, svg)
+    } else if (output.endsWith('png')) {
+      const clip = await page.$eval('svg', svg => {
+        const react = svg.getBoundingClientRect()
+        return { x: react.left, y: react.top, width: react.width, height: react.height }
+      })
+      await page.screenshot({ path: output, clip, omitBackground: backgroundColor === 'transparent' })
+    } else { // pdf
+      await page.pdf({ path: output, printBackground: backgroundColor !== 'transparent' })
+    }
+  } catch (error) {
+    rethrowError('Saving the graph output failed.', error, 4)
+  }
+}
+
+const closeBrowser = async () => {
+  try {
+    if (browser) {
+      await browser.close()
+    }
+  } catch ({ message }) {
+    logWarning('Closing Chrome failed.', message)
+  }
+}
+
+(async () => {
+  try {
+    const page = await openBrowserPage()
+    await loadGraphDefinition(page)
+    await saveGraphOutput(page)
+  } catch ({ message, details, exitCode }) {
+    logError(message, details)
+    process.exitCode = exitCode || 1
+  } finally {
+    await closeBrowser()
+  }
 })()


### PR DESCRIPTION
* Exit the process on failure instead of hanging.
* Prevent warnings about unhandled exceptions printed by Node.js.
* Print a message about the failed phase and the detailed exception message.
* Ensure a non-zero exit code.

Attempts to fix #41. Better reviewed with the white-space changes hidden.